### PR TITLE
Issue 131: change HDF5_version to HDF5_Version and remove NeXus_version

### DIFF
--- a/doc/examples/attribute_access.py
+++ b/doc/examples/attribute_access.py
@@ -19,5 +19,5 @@ for attr in r.attributes:
     print(attr.name)
 
 #access directly via name 
-print(r.attributes["NeXus_version"].name)
+print(r.attributes["HDF5_Version"].name)
 

--- a/doc/sphinx/nexus_attributes.rst
+++ b/doc/sphinx/nexus_attributes.rst
@@ -2,10 +2,10 @@ Working with attributes
 =======================
 
 Fields and groups can have attributes attached which provide additional
-metadata. In fact Nexus makes heavy use of attributes to store additional 
-information about a field or group. It is thus not recommended to use 
+metadata. In fact Nexus makes heavy use of attributes to store additional
+information about a field or group. It is thus not recommended to use
 attributes too excessively as one may runs into name conflicts with future Nexus
-development. 
+development.
 Attributes can be accessed from fields and groups via their :py:attr:`attributes`
 member. Attributes behave basically like fields with some restrictions
 
@@ -13,13 +13,13 @@ member. Attributes behave basically like fields with some restrictions
 * one cannot apply compression to attributes.
 
 Due to this restrictions one should not use attributes to store large amounts of
-data. 
+data.
 
 To create attributes use the :py:meth:`create` method of the
 :py:obj:`attributes` member
 
 .. code-block:: python
-    
+
     import pninexus.nexus as nx
 
     field = ....
@@ -35,7 +35,7 @@ optional ``shape`` keyword argument
     a = field.attributes.create("temperature",type="float32",shape=(4,4))
 
 If an attribute already exists it can be overwritten using the ``overwrite``
-keyword argument (:py:const:`False` by default). 
+keyword argument (:py:const:`False` by default).
 
 .. code-block:: python
 
@@ -53,30 +53,29 @@ queried to obtain metadata for a particular attribute instance
 ===================  =====================================================
 property             description
 ===================  =====================================================
-:py:attr:`shape`     a tuple with the number of elements along each 
-                     dimension of the attribute 
-:py:attr:`dtype`     the string representation of the attributes data type  
-:py:attr:`is_valid`  true if the attribute is a valid object 
-:py:attr:`name`      the name of the attribute (the key which can be used 
-                     to retrieve the attribute from its parent) 
-:py:attr:`value`     provides access to the attributes data 
+:py:attr:`shape`     a tuple with the number of elements along each
+                     dimension of the attribute
+:py:attr:`dtype`     the string representation of the attributes data type
+:py:attr:`is_valid`  true if the attribute is a valid object
+:py:attr:`name`      the name of the attribute (the key which can be used
+                     to retrieve the attribute from its parent)
+:py:attr:`value`     provides access to the attributes data
 :py:attr:`path`      returns the path of the attribute
 ===================  =====================================================
 
-The following code 
+The following code
 
 .. literalinclude:: ../examples/attributes_properties.py
 
-will produce 
+will produce
 
-.. code-block:: bash 
+.. code-block:: bash
 
-    HDF5_version         : /@HDF5_version       type=string     size=1                   
-    NX_class             : /@NX_class           type=string     size=1                   
-    NeXus_version        : /@NeXus_version      type=string     size=1                   
-    file_name            : /@file_name          type=string     size=1                   
-    file_time            : /@file_time          type=string     size=1                   
-    file_update_time     : /@file_update_time   type=string     size=1                   
+    HDF5_Version         : /@HDF5_Version       type=string     size=1
+    NX_class             : /@NX_class           type=string     size=1
+    file_name            : /@file_name          type=string     size=1
+    file_time            : /@file_time          type=string     size=1
+    file_update_time     : /@file_update_time   type=string     size=1
 
 
 
@@ -86,12 +85,12 @@ Attribute retrieval and iteration
 There are basically three ways to to access the attributes attached to a group
 or a field
 
-* by name via :py:meth:`__getitem__` (using `[]`) 
-* by the attributes index 
+* by name via :py:meth:`__getitem__` (using `[]`)
+* by the attributes index
 * by an iterator.
 
 The :py:attr:`attributes` attribute of groups and fields exposes an iterable
-interface. The following example shows all three ways how to access the 
+interface. The following example shows all three ways how to access the
 attributes of a files root group
 
 .. literalinclude:: ../examples/attribute_access.py
@@ -108,7 +107,7 @@ the next example
 .. literalinclude:: ../examples/attribute_io.py
 
 .. code-block:: bash
-    
+
     r= [-1.  0.  0.]
     x= -1.0
     y= 0.0
@@ -116,4 +115,3 @@ the next example
 
 There is not too much more to day about that. When reading and writing
 multidimensional data numpy arrays must be used in any case (also for strings).
-

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ from build_tools import (CppExtensionFactory,
 
 cmdclass = {'build_sphinx': BuildDoc}
 name = "pninexus"
-version = "1.3.3"
-release = "1.3.3"
+version = "1.3.4"
+release = "1.3.4"
 
 
 def get_build_dir():

--- a/src/cpp/h5cpp/_h5cpp.cpp
+++ b/src/cpp/h5cpp/_h5cpp.cpp
@@ -65,6 +65,13 @@ void print_hdf5_errors(bool value)
   hdf5::error::Singleton::instance().auto_print(value);
 }
 
+std::string current_library_version()
+{
+
+  hdf5::Version ver = hdf5::current_library_version();
+  return hdf5::Version::to_string(ver);
+}
+
 
 //=================implementation of the python extension======================
 BOOST_PYTHON_MODULE(_h5cpp)
@@ -128,6 +135,7 @@ BOOST_PYTHON_MODULE(_h5cpp)
       ;
 
   def("print_hdf5_errors",print_hdf5_errors);
+  def("current_library_version",current_library_version);
 
   exception_registration();
 }

--- a/src/pninexus/h5cpp/__init__.py
+++ b/src/pninexus/h5cpp/__init__.py
@@ -20,8 +20,9 @@ from pninexus.h5cpp._h5cpp import IterationOrder
 from pninexus.h5cpp._h5cpp import IterationIndex
 from pninexus.h5cpp._h5cpp import Path
 from pninexus.h5cpp._h5cpp import print_hdf5_errors
+from pninexus.h5cpp._h5cpp import current_library_version
 
 __all__ = ["IteratorConfig", "IterationOrder", "IterationIndex", "Path",
-           "print_hdf5_errors",
+           "print_hdf5_errors", "current_library_version",
            "attribute", "dataspace", "datatype", "file", "filter", "node",
            "property", "_h5cpp"]

--- a/test/debug/attributes_all.py
+++ b/test/debug/attributes_all.py
@@ -5,7 +5,7 @@ import numpy
 f = nexus.create_file("attributes_all.nxs", True)
 r = f.root()
 
-print(r.attributes["HDF5_version"].read())
+print(r.attributes["HDF5_Version"].read())
 
 a = r.attributes.create("temp", "uint32", shape=(2, 3))
 a.write(numpy.array([[1, 2, 3], [4, 5, 6]]))

--- a/test/h5cpp_tests/file_image.py
+++ b/test/h5cpp_tests/file_image.py
@@ -62,7 +62,7 @@ class ImageTest(unittest.TestCase):
         hdf5_version = "1.0.4"
         f1 = create(self.filename, AccessFlags.TRUNCATE)
         r1 = f1.root()
-        a1 = r1.attributes.create("HDF5_version", kVariableString)
+        a1 = r1.attributes.create("HDF5_Version", kVariableString)
         a1.write(hdf5_version)
         a1.close()
         r1.close()
@@ -71,7 +71,7 @@ class ImageTest(unittest.TestCase):
         ibuffer = np.fromfile(self.filename, dtype='uint8')
         f2 = from_buffer(ibuffer)
         r2 = f2.root()
-        a2 = r2.attributes["HDF5_version"]
+        a2 = r2.attributes["HDF5_Version"]
         self.assertTrue(a2.read(), hdf5_version)
         a2.close()
         r2.close()
@@ -84,7 +84,7 @@ class ImageTest(unittest.TestCase):
         hdf5_version = "1.0.3"
         f1 = create(self.filename, AccessFlags.TRUNCATE)
         r1 = f1.root()
-        a1 = r1.attributes.create("HDF5_version", kVariableString)
+        a1 = r1.attributes.create("HDF5_Version", kVariableString)
         a1.write(hdf5_version)
         size = f1.buffer_size
         obuffer = np.zeros(shape=[size], dtype='uint8')
@@ -97,7 +97,7 @@ class ImageTest(unittest.TestCase):
 
         f2 = h5open(self.filename2)
         r2 = f2.root()
-        a2 = r2.attributes["HDF5_version"]
+        a2 = r2.attributes["HDF5_Version"]
         self.assertTrue(a2.read(), hdf5_version)
         a2.close()
         r2.close()
@@ -110,7 +110,7 @@ class ImageTest(unittest.TestCase):
         hdf5_version = "1.0.2"
         f1 = create(self.filename, AccessFlags.TRUNCATE)
         r1 = f1.root()
-        a1 = r1.attributes.create("HDF5_version", kVariableString)
+        a1 = r1.attributes.create("HDF5_Version", kVariableString)
         a1.write(hdf5_version)
 
         size = f1.buffer_size
@@ -123,7 +123,7 @@ class ImageTest(unittest.TestCase):
 
         f2 = from_buffer(obuffer, ImageFlags.READWRITE)
         r2 = f2.root()
-        a2 = r2.attributes["HDF5_version"]
+        a2 = r2.attributes["HDF5_Version"]
         self.assertTrue(a2.read(), hdf5_version)
         a2.close()
         r2.close()

--- a/test/h5cpp_tests/path_tests.py
+++ b/test/h5cpp_tests/path_tests.py
@@ -43,6 +43,17 @@ class H5cppPathTests(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_hdf5_version(self):
+
+        hdf5ver = h5cpp.current_library_version()
+        mj, mn, pa =  hdf5ver.split(".")
+        imj = int(mj)
+        imn = int(mn)
+        ipa = int(pa)
+        self.assertTrue(imj > 0)
+        self.assertTrue(imn > -1)
+        self.assertTrue(ipa > -1)
+
     def test_default_contruction(self):
 
         p = h5cpp.Path()

--- a/test/h5cpp_tests/path_tests.py
+++ b/test/h5cpp_tests/path_tests.py
@@ -46,7 +46,7 @@ class H5cppPathTests(unittest.TestCase):
     def test_hdf5_version(self):
 
         hdf5ver = h5cpp.current_library_version()
-        mj, mn, pa =  hdf5ver.split(".")
+        mj, mn, pa = hdf5ver.split(".")
         imj = int(mj)
         imn = int(mn)
         ipa = int(pa)

--- a/test/nexus_tests/file_tests.py
+++ b/test/nexus_tests/file_tests.py
@@ -70,7 +70,6 @@ class CreatFileTest(unittest.TestCase):
         self.assertTrue(root.attributes.exists("file_time"))
         self.assertTrue(root.attributes.exists("file_update_time"))
         self.assertTrue(root.attributes.exists("file_name"))
-        self.assertTrue(root.attributes.exists("NeXus_version"))
 
         self.assertEqual(root.attributes["NX_class"].read(), "NXroot")
 


### PR DESCRIPTION
It resolve #131 by changing  `HDF5_version` to `HDF5_Version` and removing `NeXus_version`.
 It also adds a `h5cpp.current_library_version()` function