### PR TITLE
Issue 139: add HDF5_PLUGIN_PATH back to deb11 and ubuntu21.04 dockerfile

### DIFF
--- a/.ci/debian11_py3/Dockerfile
+++ b/.ci/debian11_py3/Dockerfile
@@ -17,5 +17,6 @@ RUN apt-get -qq install -y adduser
 RUN  /bin/bash -c 'sleep 10'
 
 ENV PKG_CONFIG_PATH=/home/tango/lib/pkgconfig
+ENV HDF5_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/hdf5/plugins
 USER tango
 WORKDIR /home/tango

--- a/.ci/ubuntu21.04_py3/Dockerfile
+++ b/.ci/ubuntu21.04_py3/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq install -y hdf5-plugin-bshuf hdf5-plugin-bz2 hdf5-plugin-lz4
 RUN useradd -ms /bin/bash tango
 
 ENV PKG_CONFIG_PATH=/home/tango/lib/pkgconfig
+ENV HDF5_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/hdf5/plugins
 USER tango
 WORKDIR /home/tango
 

--- a/test/h5cpp_tests/filter_tests/creation_test.py
+++ b/test/h5cpp_tests/filter_tests/creation_test.py
@@ -229,6 +229,7 @@ class FilterCreationTest(unittest.TestCase):
                 filters[0].name,
                 "bitshuffle; see https://github.com/kiyo-masui/bitshuffle")
         else:
+            raise Exception("NO bit")
             error = False
             try:
                 filter(self.dcpl)

--- a/test/h5cpp_tests/filter_tests/creation_test.py
+++ b/test/h5cpp_tests/filter_tests/creation_test.py
@@ -229,7 +229,7 @@ class FilterCreationTest(unittest.TestCase):
                 filters[0].name,
                 "bitshuffle; see https://github.com/kiyo-masui/bitshuffle")
         else:
-            raise Exception("NO bit")
+            raise Exception("Bitshuffle filter is not available")
             error = False
             try:
                 filter(self.dcpl)


### PR DESCRIPTION
We need to add HDF5_PLUGIN_PATH back to deb11 and ubuntu21.04 dockerfile. Otherwise tests cannot create a dataset with Bitshuffle filter