### PR TITLE
Issue 139: since hdf5 plugins are rebuild we can skip  ENV HDF5_PLUGIN_PATH in tests

### DIFF
--- a/.ci/debian11_py3/Dockerfile
+++ b/.ci/debian11_py3/Dockerfile
@@ -17,6 +17,5 @@ RUN apt-get -qq install -y adduser
 RUN  /bin/bash -c 'sleep 10'
 
 ENV PKG_CONFIG_PATH=/home/tango/lib/pkgconfig
-ENV HDF5_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/hdf5/plugins
 USER tango
 WORKDIR /home/tango

--- a/.ci/ubuntu21.04_py3/Dockerfile
+++ b/.ci/ubuntu21.04_py3/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get -qq install -y hdf5-plugin-bshuf hdf5-plugin-bz2 hdf5-plugin-lz4
 RUN useradd -ms /bin/bash tango
 
 ENV PKG_CONFIG_PATH=/home/tango/lib/pkgconfig
-ENV HDF5_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/hdf5/plugins
 USER tango
 WORKDIR /home/tango
 


### PR DESCRIPTION
It resolves #139