### PR TITLE
Issue 156: update SZip and ScaleOffset enums

### DIFF
--- a/src/cpp/h5cpp/filter/filter.cpp
+++ b/src/cpp/h5cpp/filter/filter.cpp
@@ -152,10 +152,17 @@ BOOST_PYTHON_MODULE(_filter)
       .value("MANDATORY",Availability::Mandatory)
       .value("OPTIONAL",Availability::Optional);
   
-  enum_<SOScaleType>("SOScaleType")
-      .value("FLOAT_DSCALE",SOScaleType::FloatDScale)
-      .value("FLOAT_ESCALE",SOScaleType::FloatEScale)
-      .value("INT",SOScaleType::Int);
+  enum_<ScaleOffset::ScaleType>("SOScaleType")
+      .value("FLOAT_DSCALE",ScaleOffset::ScaleType::FloatDScale)
+      .value("FLOAT_ESCALE",ScaleOffset::ScaleType::FloatEScale)
+      .value("INT",ScaleOffset::ScaleType::Int);
+
+  enum_<SZip::OptionMask>("SZipOptionMask")
+    .value("NONE", SZip::OptionMask::None)
+    .value("ALLOW_K13", SZip::OptionMask::AllowK13)
+    .value("CHIP", SZip::OptionMask::Chip)
+    .value("ENTROPY_CODING", SZip::OptionMask::EntropyCoding)
+    .value("NEAREST_NEIGHBOR", SZip::OptionMask::NearestNeighbor);
 
   class_<Filter,boost::noncopyable>("Filter",no_init)
       .add_property("id",&Filter::id)
@@ -175,25 +182,23 @@ BOOST_PYTHON_MODULE(_filter)
       .add_property("level",get_level,set_level)
           ;
   
-  void (SZip::*set_options_mask)(unsigned int) = &SZip::options_mask;
-  unsigned int(SZip::*get_options_mask)() const = &SZip::options_mask;
+  void (SZip::*set_option_mask)(unsigned int) = &SZip::option_mask;
+  unsigned int(SZip::*get_option_mask)() const = &SZip::option_mask;
   void (SZip::*set_pixels_per_block)(unsigned int) = &SZip::pixels_per_block;
   unsigned int(SZip::*get_pixels_per_block)() const = &SZip::pixels_per_block;
   class_<SZip,bases<Filter>>("SZip")
-    .def(init<unsigned int,unsigned int>((arg("options_mask")=32,
+    .def(init<unsigned int,unsigned int>((arg("option_mask")=32,
 					  arg("pixels_per_block")=0)))
-    .add_property("options_mask",get_options_mask,set_options_mask)
+    .add_property("option_mask",get_option_mask,set_option_mask)
     .add_property("pixels_per_block",get_pixels_per_block,set_pixels_per_block)
-    .def_readonly("EC_OPTION_MASK", &SZip::ec_option_mask)
-    .def_readonly("NN_OPTION_MASK", &SZip::nn_option_mask)
     ;
 
-  void (ScaleOffset::*set_scale_type)(SOScaleType) = &ScaleOffset::scale_type;
-  SOScaleType(ScaleOffset::*get_scale_type)() const = &ScaleOffset::scale_type;
+  void (ScaleOffset::*set_scale_type)(ScaleOffset::ScaleType) = &ScaleOffset::scale_type;
+  ScaleOffset::ScaleType(ScaleOffset::*get_scale_type)() const = &ScaleOffset::scale_type;
   void (ScaleOffset::*set_scale_factor)(int) = &ScaleOffset::scale_factor;
   int(ScaleOffset::*get_scale_factor)() const = &ScaleOffset::scale_factor;
   class_<ScaleOffset,bases<Filter>>("ScaleOffset")
-    .def(init<SOScaleType,int>((arg("scale_type")=SOScaleType::FloatDScale,
+    .def(init<ScaleOffset::ScaleType,int>((arg("scale_type")=ScaleOffset::ScaleType::FloatDScale,
 					  arg("scale_factor")=1)))
     .add_property("scale_type",get_scale_type,set_scale_type)
     .add_property("scale_factor",get_scale_factor,set_scale_factor)

--- a/src/pninexus/h5cpp/filter/__init__.py
+++ b/src/pninexus/h5cpp/filter/__init__.py
@@ -4,6 +4,7 @@ from pninexus.h5cpp._filter import Shuffle
 from pninexus.h5cpp._filter import Fletcher32
 from pninexus.h5cpp._filter import NBit
 from pninexus.h5cpp._filter import SZip
+from pninexus.h5cpp._filter import SZipOptionMask
 from pninexus.h5cpp._filter import ScaleOffset
 from pninexus.h5cpp._filter import SOScaleType
 from pninexus.h5cpp._filter import ExternalFilter
@@ -31,5 +32,6 @@ class ExternalFilters(list):
 
 
 __all__ = ["Filter", "Deflate", "Shuffle", "Fletcher32", "NBit", "SZip",
+           "SZippOptionMask"
            "ExternalFilter", "ExternalFilters", "Availability", "ScaleOffset",
            "SOScaleType", "is_filter_available"]

--- a/test/h5cpp_tests/filter_tests/creation_test.py
+++ b/test/h5cpp_tests/filter_tests/creation_test.py
@@ -27,7 +27,7 @@ import unittest
 import os
 from pninexus.h5cpp.filter import (
     Deflate, Fletcher32, Shuffle, ExternalFilter, ExternalFilters,
-    NBit, SZip, ScaleOffset, SOScaleType,
+    NBit, SZip, ScaleOffset, SOScaleType, SZipOptionMask,
     is_filter_available, Availability)
 import pninexus.h5cpp as hdf5
 
@@ -113,7 +113,7 @@ class FilterCreationTest(unittest.TestCase):
 
     def testSZip(self):
 
-        filter = SZip(SZip.EC_OPTION_MASK, 16)
+        filter = SZip(SZipOptionMask.ENTROPY_CODING, 16)
         filter(self.dcpl)
         hdf5.node.Dataset(self.root, hdf5.Path("SZip"),
                           self.datatype,


### PR DESCRIPTION
It resolves #156 by updating SZip and ScaleOffset enums

One test fails
```
self = <test.h5cpp_tests.node_tests.dataset_extent_test.DatasetExtentTest testMethod=testGrowExtentLimited>

    def testGrowExtentLimited(self):
    
        dataset = Dataset(self.root, h5cpp.Path("GrowExtentLimited"),
                          kFloat32,
                          self.limited_dataspace,
                          self.lcpl,
                          self.dcpl)
        dataset.extent(0, 10)
        self.assertEqual(dataset.dataspace.current_dimensions, (20, 10))
    
        self.assertRaises(RuntimeError, dataset.extent, 0, 90)
        self.assertRaises(RuntimeError, dataset.extent, 1, 1)
        self.assertEqual(dataset.dataspace.current_dimensions, (20, 10))
    
        #
        # shrink the dataset again
        #
>       dataset.extent(0, -2)
E       RuntimeError: input value is < 0 -> cannot be converted to unsigned

test/h5cpp_tests/node_tests/dataset_extent_test.py:121: RuntimeError
```
but it is related to https://github.com/ess-dmsc/h5cpp/issues/568 and will be fixed by https://github.com/ess-dmsc/h5cpp/issues/569